### PR TITLE
feat: use warning badge for found macs

### DIFF
--- a/src/components/MacStatusTable.tsx
+++ b/src/components/MacStatusTable.tsx
@@ -43,7 +43,7 @@ export function MacStatusTable({ macs, onStatusUpdated, showProvisionColumn = fa
         );
       case 'found':
         return (
-          <Badge variant="destructive" className="gap-1">
+          <Badge variant="warning" className="gap-1">
             <AlertTriangle className="h-3 w-3" />
             Exists
           </Badge>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -14,6 +14,8 @@ const badgeVariants = cva(
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        warning:
+          "border-transparent bg-warning text-warning-foreground hover:bg-warning/80",
         outline: "text-foreground",
       },
     },


### PR DESCRIPTION
## Summary
- add `warning` variant to Badge component
- show warning badge when MAC exists

## Testing
- `npm run lint` *(fails: Unexpected any in various files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0a05ccd1483229c4c87d70631d51f