### PR TITLE
Configure provisioning API via Vite env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+VITE_API_BASE_URL=https://ldap-api.apps.prod-ocp4.corp.cableone.net/
+VITE_USE_STUB_API=true

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,2 @@
+VITE_API_BASE_URL=https://ldap-api.apps.prod-ocp4.corp.cableone.net/
+VITE_USE_STUB_API=false

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Environment Variables
+
+The application relies on the following Vite environment variables:
+
+- `VITE_API_BASE_URL` – Base URL for the provisioning API. Defaults to `https://ldap-api.apps.prod-ocp4.corp.cableone.net/`.
+- `VITE_USE_STUB_API` – When set to `true`, the app uses a stubbed API for development. Production builds use `.env.production` which sets this to `false`.
+
+The default development values are defined in `.env` while `.env.production` ensures `VITE_USE_STUB_API=false` for production builds.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/356018a8-3148-4068-995a-374260576ddf) and click on Share -> Publish.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,11 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { provisioningApi } from '@/services/provisioningApi'
+
+provisioningApi.configure({
+  baseUrl: import.meta.env.VITE_API_BASE_URL,
+  enableStubMode: import.meta.env.VITE_USE_STUB_API === 'true',
+})
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/src/services/provisioningApi.ts
+++ b/src/services/provisioningApi.ts
@@ -1,5 +1,9 @@
 /**
- * API service for MAC provisioning operations
+ * API service for MAC provisioning operations.
+ *
+ * The API is configured at application startup using values from Vite
+ * environment variables. See `provisioningApi.configure` in `main.tsx` for
+ * details.
  */
 
 export interface MacSearchResult {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL: string
+  readonly VITE_USE_STUB_API: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}


### PR DESCRIPTION
## Summary
- add .env and .env.production with provisioning API settings
- configure provisioning API from Vite env vars on startup
- document environment variables

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any types and other lint issues)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a15b21d62c8322828f3058e8989cdc