### PR TITLE
Add Tekton pipeline and triggers for OpenShift

### DIFF
--- a/openshift/pipeline/pipeline-pvc.yaml
+++ b/openshift/pipeline/pipeline-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pipeline-workspace
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/openshift/pipeline/pipeline-run.yaml
+++ b/openshift/pipeline/pipeline-run.yaml
@@ -1,0 +1,19 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: build-and-deploy-run
+spec:
+  serviceAccountName: pipeline
+  pipelineRef:
+    name: build-and-deploy
+  params:
+    - name: git-url
+      value: https://github.com/example/repo.git
+    - name: git-revision
+      value: main
+    - name: image-url
+      value: image-registry.openshift-image-registry.svc:5000/project/app:latest
+  workspaces:
+    - name: shared-workspace
+      persistentVolumeClaim:
+        claimName: pipeline-workspace

--- a/openshift/pipeline/pipeline.yaml
+++ b/openshift/pipeline/pipeline.yaml
@@ -1,0 +1,106 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: build-and-deploy
+spec:
+  params:
+    - name: git-url
+      type: string
+    - name: git-revision
+      type: string
+      default: main
+    - name: image-url
+      type: string
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: clone-repo
+      taskRef:
+        name: git-clone
+        kind: ClusterTask
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.git-revision)
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+    - name: npm-ci
+      runAfter:
+        - clone-repo
+      taskSpec:
+        workspaces:
+          - name: source
+        steps:
+          - name: npm-ci
+            image: node:20
+            workingDir: $(workspaces.source.path)
+            script: |
+              npm ci
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+    - name: lint
+      runAfter:
+        - npm-ci
+      taskSpec:
+        workspaces:
+          - name: source
+        steps:
+          - name: lint
+            image: node:20
+            workingDir: $(workspaces.source.path)
+            script: |
+              npm run lint
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+    - name: test
+      runAfter:
+        - lint
+      taskSpec:
+        workspaces:
+          - name: source
+        steps:
+          - name: test
+            image: node:20
+            workingDir: $(workspaces.source.path)
+            script: |
+              npm run test -- --run
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+    - name: build-image
+      runAfter:
+        - test
+      taskRef:
+        name: buildah
+        kind: ClusterTask
+      params:
+        - name: IMAGE
+          value: $(params.image-url)
+        - name: CONTEXT
+          value: $(workspaces.source.path)
+        - name: DOCKERFILE
+          value: $(workspaces.source.path)/Dockerfile
+        - name: TLSVERIFY
+          value: "false"
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+    - name: apply-manifests
+      runAfter:
+        - build-image
+      taskSpec:
+        workspaces:
+          - name: source
+        steps:
+          - name: oc-apply
+            image: quay.io/openshift/origin-cli:latest
+            workingDir: $(workspaces.source.path)
+            script: |
+              oc apply -f openshift
+      workspaces:
+        - name: source
+          workspace: shared-workspace

--- a/openshift/pipeline/trigger.yaml
+++ b/openshift/pipeline/trigger.yaml
@@ -1,0 +1,57 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerBinding
+metadata:
+  name: github-push-binding
+spec:
+  params:
+    - name: git-url
+      value: $(body.repository.clone_url)
+    - name: git-revision
+      value: $(body.ref)
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: build-and-deploy-template
+spec:
+  params:
+    - name: git-url
+    - name: git-revision
+    - name: image-url
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1
+      kind: PipelineRun
+      metadata:
+        generateName: build-and-deploy-run-
+      spec:
+        serviceAccountName: pipeline
+        pipelineRef:
+          name: build-and-deploy
+        params:
+          - name: git-url
+            value: $(tt.params.git-url)
+          - name: git-revision
+            value: $(tt.params.git-revision)
+          - name: image-url
+            value: $(tt.params.image-url)
+        workspaces:
+          - name: shared-workspace
+            persistentVolumeClaim:
+              claimName: pipeline-workspace
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: github-listener
+spec:
+  serviceAccountName: pipeline
+  triggers:
+    - name: github-push
+      bindings:
+        - ref: github-push-binding
+      template:
+        ref: build-and-deploy-template
+      interceptors:
+        - github:
+            eventTypes:
+              - push


### PR DESCRIPTION
## Summary
- add persistent volume claim for Tekton workspace
- create build-and-deploy Tekton pipeline with npm, build and deploy steps
- include PipelineRun, service account reference, and GitHub webhook trigger resources

## Testing
- `npm run lint` (fails: Unexpected any / require import)
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a2bb1fa72883229e5207e9fa12cc2b