### PR TITLE
refactor: tighten provisioning types

### DIFF
--- a/src/components/MacStatusTable.tsx
+++ b/src/components/MacStatusTable.tsx
@@ -13,7 +13,7 @@ export interface MacStatus {
     account: string;
     configfile: string;
     isp: string;
-    customFields?: any;
+    customFields?: Record<string, unknown>;
   };
   error?: string;
   provisionState: 'pending' | 'provisioning' | 'complete' | 'error';

--- a/src/services/provisioningApi.ts
+++ b/src/services/provisioningApi.ts
@@ -11,7 +11,7 @@ export interface MacSearchResult {
   account: string;
   configfile: string;
   isp: string;
-  customFields?: any;
+  customFields?: Record<string, unknown>;
 }
 
 export interface ProvisionRequest {


### PR DESCRIPTION
## Summary
- replace `any` custom field types with `Record<string, unknown>`
- define `ProvisionDefaults` interface and type React state accordingly
- ensure provisioning logic uses typed defaults

## Testing
- `npm run lint` (fails: existing lint errors)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2c097ca54832293afe387ca4a26b2