### PR TITLE
test: refine provisioning mocks

### DIFF
--- a/src/components/ProvisioningPage.test.tsx
+++ b/src/components/ProvisioningPage.test.tsx
@@ -10,19 +10,19 @@ vi.mock('@/services/provisioningApi', () => ({
   }
 }));
 
-const fetchMock = vi.fn((input: RequestInfo) => {
+const fetchMock = vi.fn<typeof fetch>(async (input: RequestInfo) => {
   if (typeof input === 'string' && input.endsWith('approved-ouis.json')) {
-    return Promise.resolve({ ok: true, json: () => Promise.resolve({ approved_ouis: ['A1B2C3'] }) });
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ approved_ouis: ['A1B2C3'] }) } as Response);
   }
   if (typeof input === 'string' && input.endsWith('provision-defaults.json')) {
-    return Promise.resolve({ ok: true, json: () => Promise.resolve({ account: 'acct', isp: 'isp', configfiles: ['cfg0','cfg1','cfg2','cfg3'] }) });
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ account: 'acct', isp: 'isp', configfiles: ['cfg0','cfg1','cfg2','cfg3'] }) } as Response);
   }
   return Promise.reject(new Error('Unknown fetch'));
 });
 
 describe('ProvisioningPage sequential provisioning', () => {
   it('provisions MACs sequentially after validation', async () => {
-    global.fetch = fetchMock as any;
+    global.fetch = fetchMock as typeof fetch;
     const user = userEvent.setup();
     const { provisioningApi } = await import('@/services/provisioningApi');
 
@@ -32,11 +32,11 @@ describe('ProvisioningPage sequential provisioning', () => {
     await user.type(input, 'A1B2C3000000');
     await user.click(screen.getByText('Validate'));
 
-    await waitFor(() => expect(provisioningApi.searchByMac).toHaveBeenCalled());
+    await waitFor(() => expect(vi.mocked(provisioningApi.searchByMac)).toHaveBeenCalled());
     await user.click(screen.getByText('Provision MACs'));
 
-    await waitFor(() => expect(provisioningApi.addHsd).toHaveBeenCalledTimes(4));
-    const calls = (provisioningApi.addHsd as any).mock.calls;
+    await waitFor(() => expect(vi.mocked(provisioningApi.addHsd)).toHaveBeenCalledTimes(4));
+    const calls = vi.mocked(provisioningApi.addHsd).mock.calls;
     expect(calls[0][0].mac).toBe('A1:B2:C3:00:00:00');
     expect(calls[1][0].mac).toBe('A1:B2:C3:00:00:01');
     expect(calls[2][0].mac).toBe('A1:B2:C3:00:00:02');


### PR DESCRIPTION
## Summary
- use `vi.mocked` helper in provisioning tests
- cast mock fetch functions to `typeof fetch`

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a2c1c1f2148322b32cce382da123f9