### PR TITLE
feat: add multi-stage Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,4 @@
 node_modules
 dist
 *.log
-.env
-.env.*
-*.local
+.env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage build for Viavi Meter Provisioning
 
 # Builder stage
-FROM registry.access.redhat.com/ubi9/nodejs-20 as builder
+FROM registry.access.redhat.com/ubi9/nodejs-20 AS builder
 WORKDIR /opt/app-root/src
 COPY package*.json ./
 RUN npm ci
@@ -9,13 +9,11 @@ COPY . .
 RUN npm run build
 
 # Runtime stage
-FROM registry.access.redhat.com/ubi9/nodejs-20 as runtime
+FROM registry.access.redhat.com/ubi9/nodejs-20
 WORKDIR /opt/app-root/src
 ENV NODE_ENV=production \
     PORT=8080 \
     HOME=/opt/app-root/home
 COPY --from=builder /opt/app-root/src/dist ./dist
-COPY --from=builder /opt/app-root/src/package*.json ./
-COPY --from=builder /opt/app-root/src/node_modules ./node_modules
 EXPOSE 8080
-CMD ["npm", "run", "preview", "--", "--port", "8080"]
+CMD ["node", "dist/server.js"]


### PR DESCRIPTION
## Summary
- build app with a multi-stage Dockerfile and production runtime
- ignore build artifacts, logs, env files, and node_modules in Docker contexts

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a34622f6008322a985391704bc50f9