### PR TITLE
Configure Tekton pipeline resources and RBAC

### DIFF
--- a/openshift/pipeline/registry-secret.yaml
+++ b/openshift/pipeline/registry-secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-credentials
+  annotations:
+    tekton.dev/docker-0: https://image-registry.openshift-image-registry.svc:5000
+    # Add additional registry URLs as needed
+  labels:
+    app: viavi-meter
+# Use basic auth for registry credentials. Provide your own values when applying.
+type: kubernetes.io/basic-auth
+stringData:
+  username: YOUR_REGISTRY_USERNAME
+  password: YOUR_REGISTRY_PASSWORD

--- a/openshift/pipeline/service-account.yaml
+++ b/openshift/pipeline/service-account.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipeline
+secrets:
+  - name: registry-credentials
+imagePullSecrets:
+  - name: registry-credentials
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pipeline-edit
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pipeline-image-pusher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:image-builder
+subjects:
+  - kind: ServiceAccount
+    name: pipeline


### PR DESCRIPTION
## Summary
- Define registry credentials secret for Tekton builds
- Add pipeline service account with RBAC for image pushes and manifest apply

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a34d0bcb98832287fab567059cd467