### PR TITLE
docs: expand OpenShift deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ npm run test src/e2e
 
 Simply open [Lovable](https://lovable.dev/projects/356018a8-3148-4068-995a-374260576ddf) and click on Share -> Publish.
 
-For cluster deployment on OpenShift using the `oc` CLI and Tekton pipelines, see the [OpenShift deployment guide](docs/openshift-deployment.md).
+For cluster deployment on OpenShift, including commands for applying manifests, required environment variables, and triggering the Tekton pipeline on Git commits, see the [OpenShift deployment guide](docs/openshift-deployment.md).
 
 ## Can I connect a custom domain to my Lovable project?
 

--- a/docs/openshift-deployment.md
+++ b/docs/openshift-deployment.md
@@ -1,47 +1,65 @@
 # OpenShift Deployment
 
-This guide describes how to deploy the VIAVI Meter Provisioning application to an OpenShift cluster.
+This guide describes how to deploy the VIAVI Meter Provisioning application to an OpenShift cluster and configure the Tekton pipeline.
 
 ## Apply Application Manifests
 
-Ensure you are logged in to the target cluster with the `oc` CLI.
+Ensure you are logged in to the target cluster with the `oc` CLI and then apply the application manifests:
 
 ```sh
-# Deploy service, route, network policy and deployment
 oc apply -f openshift/
 ```
 
-## Environment Configuration
+## Required Configuration
 
-The deployment expects configuration values and secrets to be supplied via a ConfigMap and Secret.  Create them before applying the manifests:
+Create a ConfigMap and Secret to supply runtime configuration and credentials:
 
 ```sh
 oc create configmap app-config \
-  --from-literal=VITE_SUPABASE_URL=<supabase-url>
+  --from-literal=VITE_API_BASE_URL=<api-url> \
+  --from-literal=VITE_SUPABASE_URL=<supabase-url> \
+  --from-literal=VITE_USE_STUB_API=false
 
 oc create secret generic app-secrets \
   --from-literal=VITE_SUPABASE_ANON_KEY=<anon-key>
 ```
 
-Update the values to match your environment.
+Update the placeholder values to match your environment. The `VITE_SUPABASE_ANON_KEY` should remain secret.
 
-## Pipeline and Trigger Setup
+## Pipeline Resources
 
-Tekton resources are provided to automate builds and deployments.
+Tekton resources automate build and deployment tasks:
 
 ```sh
-# Persistent volume for the workspace
+# Persistent volume for the shared workspace
 oc apply -f openshift/pipeline/pipeline-pvc.yaml
+
+# Registry credentials and service account
+oc apply -f openshift/pipeline/registry-secret.yaml
+oc apply -f openshift/pipeline/service-account.yaml
 
 # Pipeline definition and trigger configuration
 oc apply -f openshift/pipeline/pipeline.yaml
 oc apply -f openshift/pipeline/trigger.yaml
 ```
 
-Create a PipelineRun to execute the pipeline:
+Run the pipeline manually with:
 
 ```sh
 oc create -f openshift/pipeline/pipeline-run.yaml
 ```
 
-The pipeline clones the repository, installs dependencies, lints, tests, builds a container image, and applies the OpenShift manifests. When a run completes successfully, a new image is pushed to the internal registry and the application is redeployed.
+## Triggering on Git Commits
+
+`trigger.yaml` installs an EventListener that responds to GitHub push events and starts the pipeline.
+
+1. Expose the EventListener service to create a webhook endpoint:
+
+```sh
+oc expose service el-github-listener
+```
+
+2. In your Git hosting service, create a webhook pointing to the route URL and enable **push** events.
+
+When commits are pushed, the webhook calls the EventListener and a new `PipelineRun` is created to build the image and apply the manifests.
+


### PR DESCRIPTION
## Summary
- expand OpenShift deployment guide with config map, secret, pipeline resources, and git trigger setup
- reference deployment guide from README for commands, required variables, and pipeline trigger details

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a35898d8f08322bc54a80d90c7d9e0