### PR TITLE
chore: add multi-stage dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,7 @@ RUN npm run build
 # Runtime stage
 FROM registry.access.redhat.com/ubi9/nodejs-20
 WORKDIR /opt/app-root/src
-ENV NODE_ENV=production \
-    PORT=8080 \
-    HOME=/opt/app-root/home
 COPY --from=builder /opt/app-root/src/dist ./dist
+ENV NODE_ENV=production PORT=8080 HOME=/opt/app-root/home
 EXPOSE 8080
-CMD ["node", "dist/server.js"]
+CMD ["npx", "vite", "preview", "--port", "8080", "--strictPort"]


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile targeting Red Hat's Node.js 20 image
- ensure Docker ignore rules for node_modules, build outputs, logs and env files

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a36989116c8322a6587d08406abd56