### PR TITLE
Add OpenShift deployment and networking configuration

### DIFF
--- a/openshift/deployment.yaml
+++ b/openshift/deployment.yaml
@@ -20,15 +20,15 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001580000
-        runAsGroup: 10000
-        fsGroup: 10000
+        runAsGroup: 1001580000
+        fsGroup: 1001580000
         seLinuxOptions:
           level: "s0:c40,c10"
         supplementalGroups:
-          - 10000
+          - 1001580000
       containers:
         - name: viavi-meter-provisioning
-          image: registry.access.redhat.com/ubi9/nodejs-20
+          image: image-registry.openshift-image-registry.svc:5000/project/viavi-meter-provisioning:latest
           env:
             - name: NODE_ENV
               value: "production"
@@ -36,6 +36,16 @@ spec:
               value: "8080"
             - name: HOME
               value: "/opt/app-root/home"
+            - name: VITE_API_BASE_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: VITE_API_BASE_URL
+            - name: VITE_USE_STUB_API
+              valueFrom:
+                configMapKeyRef:
+                  name: app-config
+                  key: VITE_USE_STUB_API
             - name: VITE_SUPABASE_URL
               valueFrom:
                 configMapKeyRef:

--- a/openshift/network-policy.yaml
+++ b/openshift/network-policy.yaml
@@ -1,4 +1,4 @@
-# Allow ingress traffic from the OpenShift router
+# Allow ingress traffic from the OpenShift router; all other ingress is denied
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/openshift/route.yaml
+++ b/openshift/route.yaml
@@ -1,3 +1,4 @@
+# Routes external traffic to the service with TLS termination
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/openshift/service.yaml
+++ b/openshift/service.yaml
@@ -12,3 +12,4 @@ spec:
     - name: http
       port: 8080
       targetPort: 8080
+      protocol: TCP


### PR DESCRIPTION
## Summary
- configure deployment to use built image with env vars and strict security context
- expose app via service, route with TLS, and network policy allowing router only

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a37654d0048322bb705289859ff126