### PR TITLE
docs: clarify OpenShift deployment and trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ npm run test src/e2e
 
 Simply open [Lovable](https://lovable.dev/projects/356018a8-3148-4068-995a-374260576ddf) and click on Share -> Publish.
 
-For cluster deployment on OpenShift, including commands for applying manifests, required environment variables, and triggering the Tekton pipeline on Git commits, see the [OpenShift deployment guide](docs/openshift-deployment.md).
+For cluster deployment on OpenShift, including commands for applying manifests, required environment variables and secrets, configuring the Route, and triggering the Tekton pipeline via webhook, see the [OpenShift deployment guide](docs/openshift-deployment.md).
 
 ## Can I connect a custom domain to my Lovable project?
 

--- a/docs/openshift-deployment.md
+++ b/docs/openshift-deployment.md
@@ -10,7 +10,7 @@ Ensure you are logged in to the target cluster with the `oc` CLI and then apply 
 oc apply -f openshift/
 ```
 
-## Required Configuration
+## Required Environment Variables and Secrets
 
 Create a ConfigMap and Secret to supply runtime configuration and credentials:
 
@@ -49,17 +49,16 @@ Run the pipeline manually with:
 oc create -f openshift/pipeline/pipeline-run.yaml
 ```
 
-## Triggering on Git Commits
+## Configure Route and Webhook Trigger
 
-`trigger.yaml` installs an EventListener that responds to GitHub push events and starts the pipeline.
-
-1. Expose the EventListener service to create a webhook endpoint:
+Expose the application and Tekton EventListener via routes:
 
 ```sh
+# Application route
+oc apply -f openshift/route.yaml
+
+# EventListener route for Git webhooks
 oc expose service el-github-listener
 ```
 
-2. In your Git hosting service, create a webhook pointing to the route URL and enable **push** events.
-
-When commits are pushed, the webhook calls the EventListener and a new `PipelineRun` is created to build the image and apply the manifests.
-
+In your Git hosting service, create a webhook pointing to the EventListener route URL and enable **push** events. When commits are pushed, the webhook calls the EventListener and a new `PipelineRun` is created to build the image and apply the manifests.


### PR DESCRIPTION
## Summary
- document required env vars and secrets for OpenShift deployment
- explain how to expose the Route and configure webhook trigger
- link OpenShift deployment guide in README

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a37d70a4d8832282208f0f0126fbcf