### PR TITLE
chore: configure npm prefix in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN npm run build
 FROM registry.access.redhat.com/ubi9/nodejs-20
 WORKDIR /opt/app-root/src
 COPY --from=builder /opt/app-root/src/dist ./dist
-ENV NODE_ENV=production PORT=8080 HOME=/opt/app-root/home
+ENV NODE_ENV=production PORT=8080 HOME=/opt/app-root/home NPM_CONFIG_PREFIX=/opt/app-root/home/.npm-global
+RUN mkdir -p $NPM_CONFIG_PREFIX
 EXPOSE 8080
 CMD ["npx", "vite", "preview", "--port", "8080", "--strictPort"]


### PR DESCRIPTION
## Summary
- set npm global prefix during runtime
- create directory for npm global packages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a38d360a708322b00e33321edec40e