### PR TITLE
Externalize Supabase config and align OpenShift resources

### DIFF
--- a/openshift/deployment.yaml
+++ b/openshift/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           - 1001580000
       containers:
         - name: viavi-meter-provisioning
-          image: image-registry.openshift-image-registry.svc:5000/project/viavi-meter-provisioning:latest
+          image: image-registry.openshift-image-registry.svc:5000/viavi-meter-provisioning/viavi-meter-provisioning:latest
           env:
             - name: NODE_ENV
               value: "production"

--- a/openshift/pipeline/pipeline-run.yaml
+++ b/openshift/pipeline/pipeline-run.yaml
@@ -8,11 +8,11 @@ spec:
     name: build-and-deploy
   params:
     - name: git-url
-      value: https://github.com/example/repo.git
+      value: https://github.com/LoneWolf345/viavi-meter-provisioning.git
     - name: git-revision
       value: main
     - name: image-url
-      value: image-registry.openshift-image-registry.svc:5000/project/app:latest
+      value: image-registry.openshift-image-registry.svc:5000/viavi-meter-provisioning/viavi-meter-provisioning:latest
   workspaces:
     - name: shared-workspace
       persistentVolumeClaim:

--- a/openshift/pipeline/trigger.yaml
+++ b/openshift/pipeline/trigger.yaml
@@ -17,7 +17,9 @@ spec:
   params:
     - name: git-url
     - name: git-revision
+      default: main
     - name: image-url
+      default: image-registry.openshift-image-registry.svc:5000/viavi-meter-provisioning/viavi-meter-provisioning:latest
   resourcetemplates:
     - apiVersion: tekton.dev/v1
       kind: PipelineRun

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,16 +2,16 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://lombpdlxtsxvrmionlfv.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxvbWJwZGx4dHN4dnJtaW9ubGZ2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUyOTAyNTAsImV4cCI6MjA3MDg2NjI1MH0.wtcwd3jCx2YmajMUgejtiXV7JwfqYawk30A-HYmd0Us";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 
-export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, {
+export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
   auth: {
     storage: localStorage,
     persistSession: true,
     autoRefreshToken: true,
-  }
+  },
 });

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,8 @@
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string
   readonly VITE_USE_STUB_API: string
+  readonly VITE_SUPABASE_URL: string
+  readonly VITE_SUPABASE_ANON_KEY: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- load Supabase credentials from Vite environment variables instead of hard-coded values
- type new Supabase env vars and reference project image in OpenShift deployment
- point pipeline resources at this repository and default image, enabling automated builds

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2aeb9e53c8322ada09f66740715fd